### PR TITLE
[Adjustment][Ronnel] Adjust game round timer and lobby state updates.

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,7 @@ import { LobbyStateType, ScenarioConfigurationType, SectorEnum, SectorsButtonCon
 import { getRandomEffectValue } from "./utils";
 
 export const ROOM_NAME = "rooms-v5";
-export const GAME_ROUND_TIMER = 300000;
+export const GAME_ROUND_TIMER = 30;
 export const GAME_STARST_IN_COUNTDOWN = 15;
 export const DELAY_IN_SECONDS_BEFORE_GAME_STARST_IN_COUNTDOWN = 3;
 export const OVERALL_SCORE_POINTS = 2500;

--- a/src/pages/admin-phase-control.tsx
+++ b/src/pages/admin-phase-control.tsx
@@ -156,6 +156,7 @@ export default function AdminPhaseControl() {
       await gameRoomService.updateLobbyState(lobbyStateDefaultValue);
       
       // Explicitly set phase to INTRODUCTION and round to 1
+      await gameRoomService.updateLobbyStateKeyValue(LobbyStateEnum.GAME_LOBBY_STATUS, GameLobbyStatus.INTRODUCTION);
       await gameRoomService.updateLobbyStateKeyValue(LobbyStateEnum.GAME_LOBBY_STATUS, GameLobbyStatus.INITIALIZING);
       await gameRoomService.updateLobbyStateKeyValue(LobbyStateEnum.ROUND, 0);
       


### PR DESCRIPTION
Updated `GAME_ROUND_TIMER` to a shorter duration for testing. Added explicit transition to the `INTRODUCTION` phase in lobby state updates to ensure correct phase initialization.