### PR TITLE
Adjust sector score thresholds for performance

### DIFF
--- a/src/components/hooks/useSectorScores.ts
+++ b/src/components/hooks/useSectorScores.ts
@@ -75,8 +75,8 @@ const getSectorPerformance = (
 
 const getTotalPerformance = (totalScore: number): SectorPerformance => {
   if (totalScore >= 2200) return 'good';
-  if (totalScore >= 1500) return 'okay';
-  return 'bad'; // < 1500
+  if (totalScore >= 1600) return 'okay';
+  return 'bad'; // < 1599
 };
 
 export function useSectorScores({


### PR DESCRIPTION
Refined the threshold for "okay" performance to start at 1600 instead of 1500. This update enhances scoring accuracy and aligns with the latest balancing standards.